### PR TITLE
Questao4

### DIFF
--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Employee.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Employee.java
@@ -30,4 +30,8 @@ public class Employee {
 	public void setGrade(double grade) {
 		this.grade = grade;
 	}
+
+	public double totalGrade() {
+		return getGrade();
+	}
 }

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Manager.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Manager.java
@@ -27,6 +27,7 @@ public class Manager extends Employee {
 		managed.get(position).setGrade(grade);
 	}
 
+	@Override
 	public double totalGrade() {
 		double managedSum = 0;
 		for (Employee employee : managed.values()) {

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Manager.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Manager.java
@@ -26,4 +26,13 @@ public class Manager extends Employee {
 	public void evaluate(String position, double grade) {
 		managed.get(position).setGrade(grade);
 	}
+
+	public double totalGrade() {
+		double managedSum = 0;
+		for (Employee employee : managed.values()) {
+			managedSum += employee.getGrade();
+		}
+
+		return managedSum + (getGrade() + managedSum / managed.size()) / 2;
+	}
 }

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Manager.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Manager.java
@@ -3,37 +3,12 @@ package br.edu.insper.desagil.pi.qulture;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Manager {
-	private int id;
-	private String name;
-	private double grade;
+public class Manager extends Employee {
 	private Map<String, Employee> managed;
 
 	public Manager(int id, String name) {
-		this.id = id;
-		this.name = name;
-		this.grade = 0;
+		super(id, name);
 		this.managed = new HashMap<>();
-	}
-
-	public int getId() {
-		return id;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public double getGrade() {
-		return grade;
-	}
-
-	public void setGrade(double grade) {
-		this.grade = grade;
 	}
 
 	public Map<String, Employee> getManaged() {

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
@@ -4,24 +4,19 @@ import java.util.List;
 
 public class Summarizer {
 	private List<Employee> employees;
-	private List<Manager> managers;
 
 	public Summarizer(List<Employee> employees, List<Manager> managers) {
 		this.employees = employees;
-		this.managers = managers;
+		for (Manager manager : managers) {
+			this.employees.add(manager);
+		}
 	}
 
 	public double summarize() {
 		double sum = 0;
-
 		for (Employee employee : employees) {
 			sum += employee.totalGrade();
 		}
-
-		for (Manager manager : managers) {
-			sum += manager.totalGrade();
-		}
-
-		return sum / (employees.size() + managers.size());
+		return sum / (employees.size());
 	}
 }

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
@@ -23,15 +23,13 @@ public class Summarizer {
 			}
 
 			for (Manager manager : managers) {
-				double managedSum = 0;
 				Map<String, Employee> managed = manager.getManaged();
 
-				if (!managed.isEmpty()) {
-					for (Employee employee : managed.values()) {
-						managedSum += employee.getGrade();
-					}
-					sum += managedSum;
+				double managedSum = 0;
+				for (Employee employee : managed.values()) {
+					managedSum += employee.getGrade();
 				}
+				sum += managedSum;
 
 				sum += (manager.getGrade() + managedSum / managed.size()) / 2;
 			}

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
@@ -29,9 +29,8 @@ public class Summarizer {
 				for (Employee employee : managed.values()) {
 					managedSum += employee.getGrade();
 				}
-				sum += managedSum;
 
-				sum += (manager.getGrade() + managedSum / managed.size()) / 2;
+				sum += managedSum + (manager.getGrade() + managedSum / managed.size()) / 2;
 			}
 		}
 

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
@@ -13,19 +13,15 @@ public class Summarizer {
 
 	public double summarize() {
 		double sum = 0;
-		int employeesSize = employees.size();
-		int managersSize = managers.size();
 
-		if (employeesSize != 0 || managersSize != 0) {
-			for (Employee employee : employees) {
-				sum += employee.getGrade();
-			}
-
-			for (Manager manager : managers) {
-				sum += manager.totalGrade();
-			}
+		for (Employee employee : employees) {
+			sum += employee.getGrade();
 		}
 
-		return sum / (employeesSize + managersSize);
+		for (Manager manager : managers) {
+			sum += manager.totalGrade();
+		}
+
+		return sum / (employees.size() + managers.size());
 	}
 }

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
@@ -15,7 +15,7 @@ public class Summarizer {
 		double sum = 0;
 
 		for (Employee employee : employees) {
-			sum += employee.getGrade();
+			sum += employee.totalGrade();
 		}
 
 		for (Manager manager : managers) {

--- a/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
+++ b/qulture/src/main/java/br/edu/insper/desagil/pi/qulture/Summarizer.java
@@ -1,7 +1,6 @@
 package br.edu.insper.desagil.pi.qulture;
 
 import java.util.List;
-import java.util.Map;
 
 public class Summarizer {
 	private List<Employee> employees;
@@ -23,14 +22,7 @@ public class Summarizer {
 			}
 
 			for (Manager manager : managers) {
-				Map<String, Employee> managed = manager.getManaged();
-
-				double managedSum = 0;
-				for (Employee employee : managed.values()) {
-					managedSum += employee.getGrade();
-				}
-
-				sum += managedSum + (manager.getGrade() + managedSum / managed.size()) / 2;
+				sum += manager.totalGrade();
 			}
 		}
 


### PR DESCRIPTION
Este pull request contém uma sequência de refatorações que visam aproveitar oportunidades de abstração e melhorar a coesão do projeto `qulture`.

**1) Transformação de `Manager` em subclasse de `Employee`**

*Possibilidade de resposta A:*

Esta refatoração aproveita uma oportunidade de abstração. Como um gerente é um caso particular de funcionário, a classe `Manager` originalmente repetia os atributos `id`, `name` e `grade` da classe `Employee`, pois esses atributos representam informações necessárias para qualquer funcionário, inclusive gerentes. Ao transformar `Manager` em uma subclasse de `Employee`, eliminamos a necessidade desses atributos. Ou seja, substituímos detalhes de implementação ("um gerente tem id, nome e nota") por um conceito de alto nível ("um gerente é um funcionário").

*Possibilidade de resposta B:*

Esta refatoração melhora a coesão da classe `Manager`. Originalmente, o código dessa classe definia tanto responsabilidades gerais de funcionário quanto responsabilidades específicas de gerente. Como essas responsabilidades gerais já estavam definidas na classe `Employee`, transformamos `Manager` em uma subclasse dela para que possa simplesmente herdá-las. Dessa forma, o código de `Manager` ficou restrito a responsabilidades específicas de gerente.

*Repare que, em ambas as respostas, a eliminação de repetição não foi a motivação. Ela é apenas um bônus.*

**2) Remoção de `if` desnecessário no método `summarize` de `Summarizer`**

*(Observação: Esta refatoração não está diretamente relacionada a abstração e coesão e, portanto, não seria aceita como resposta por si só. Ela está separada apenas para garantir que os commits não misturem intenções diferentes e, portanto, possam ser entendidos mais facilmente.)*

No método `summarize` de `Summarizer`, foi constatado que o `if` no loop de gerentes é desnecessário. Quando o dicionário `managed` está vazio, o loop em `managed.values()` não executa nenhuma iteração e o valor zero é adicionado a `sum`. Ou seja, esse caso não tem efeito e, portanto, não precisa ser explicitamente ignorado.

**3) Junção de somas desnecessariamente separadas no método `summarize` de `Summarizer`**

*(Observação: Esta refatoração não está diretamente relacionada a abstração e coesão e, portanto, não seria aceita como resposta por si só. Ela está separada apenas para garantir que os commits não misturem intenções diferentes e, portanto, possam ser entendidos mais facilmente.)*

Depois da refatoração anterior, foi constatado que não havia necessidade de separar as adições a `sum`. Elas podem ocorrer na mesma linha. Isso facilita a próxima refatoração.

**4) Encapsulamento do cálculo da nota do `Manager` em um método próprio**

*Possibilidade de resposta A:*

Esta refatoração aproveita uma oportunidade de abstração. Depois da refatoração anterior, ficou explícito que o loop de gerentes simplesmente calcula uma nota total do gerente e soma essa nota total a `sum`. Como esse cálculo depende apenas de atributos de `Manager`, ele foi encapsulado em um método dessa classe. Ou seja, substituímos detalhes de implementação (como o cálculo é feito) por um conceito de alto nível ("chamamos um método que devolve a nota total do gerente").

*Possibilidade de resposta B:*

Esta refatoração melhora a coesão do método `summarize` de `Summarizer`. Depois da refatoração anterior, ficou explícito que o loop de gerentes simplesmente calcula uma nota total do gerente e soma essa nota total a `sum`. Como esse cálculo depende apenas de atributos de `Manager`, ele foi encapsulado em um método dessa classe. Ou seja, `summarize` passou a delegar a responsabilidade de calcular o total do gerente para o próprio gerente, em vez de ter essa responsabilidade junto com todas as outras que já possui.

*Repare que, em ambas as respostas, não é relevante saber qual é a lógica por trás do cálculo.*

**5) Remoção de variáveis e `if`s desnecessários do método `summarize` de `Summarizer`**

*(Observação: Esta refatoração não está diretamente relacionada a abstração e coesão e, portanto, não seria aceita como resposta por si só. Ela está separada apenas para garantir que os commits não misturem intenções diferentes e, portanto, possam ser entendidos mais facilmente.)*

Depois da refatoração anterior, foi constatado que o `if` que restou no método também é desnecessário. Quando ambas as listas estão vazias, os dois loops simplesmente não executam nenhuma iteração. Ou seja, não é efeito.

No método `summarize` de `Summarizer`, foi constatado que o `if` no loop de gerentes é desnecessário. Quando o dicionário `managed` está vazio, o loop em `managed.values()` não executa nenhuma iteração e o valor zero é adicionado a `sum`. Ou seja, esse caso não tem efeito e, portanto, não precisa ser explicitamente ignorado.

Essa mudança elimina a necessidade de variáveis para armazenar os tamanhos, pois são necessários apenas uma vez.

**6) Encapsulamento do cálculo da nota em um método de `Employee` que `Manager` sobrescreve**

*(Observação: Esta refatoração, ainda que relacionada a abstração e coesão, só faz sentido no contexto das outras. Portanto, não seria aceita como resposta por si só. Ela está separada apenas para garantir que os commits não misturem intenções diferentes e, portanto, possam ser entendidos mais facilmente.)*

Considerando as refatorações anteriores, podemos observar que é possível generalizar o conceito de "calcular nota total" para todos os funcionários, simplesmente estabelecendo que, quando o funcionário não é gerente, esse cálculo corresponde simplesmente a devolver `grade`.

**7) Eliminação da lista de `Manager`s em `Summarizer`**

Esta refatoração melhora a coesão de `Summarizer`. Originalmente, essa classe separava os funcionários em duas listas, uma para funcionários comuns e outra para gerentes. No entanto, depois das refatorações anteriores, ficou evidente que as ações que são tomadas para uma lista são iguais às ações que são tomadas para outra. Portanto, podemos usar apenas uma lista. Ou seja, a responsabilidade de realizar cálculos diferentes foi delegada para o sistema de sobrescrita do Java em vez de ser do método `summarize`.

Futuramente, podemos considerar um construtor que receba apenas uma lista. Isso não foi feito no momento para não correr o risco de quebrar código que chame o construtor original.